### PR TITLE
fix release type for aarch64 -> armhfp

### DIFF
--- a/installer/fedora/defaults
+++ b/installer/fedora/defaults
@@ -7,7 +7,7 @@
 # It must set at least ARCH and MIRROR if not already specified.
 
 if [ -z "$ARCH" ]; then
-    ARCH="`uname -m | sed -e 's i.86 i386 ;s arm.* armhfp ;'`"
+    ARCH="`uname -m | sed -e 's i.86 i386 ;s arm.* armhfp ;s aarch64 armhfp '`"
 fi
 
 # Latest Koji builds


### PR DESCRIPTION
unname -m reports aarch64.  map this to armhfp which is the docker release name